### PR TITLE
1. Adding new filter - Group filter which is visible only when two ot…

### DIFF
--- a/DALK.PL_ANALYZER/DALK.PL_ANALYZER.csproj
+++ b/DALK.PL_ANALYZER/DALK.PL_ANALYZER.csproj
@@ -141,9 +141,11 @@
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
     <Compile Include="DB\FAKE\FakeDB.cs" />
+    <Compile Include="Models\Filters\FilterDataCohesion.cs" />
     <Compile Include="Models\Filters\GridFilters.cs" />
     <Compile Include="Models\Filters\IFilterableList.cs" />
     <Compile Include="Models\Filters\ItemInFilterData.cs" />
+    <Compile Include="Models\Filters\RawFiltarableValues.cs" />
     <Compile Include="Models\Filters\RawFilterValues.cs" />
     <Compile Include="Models\Matches\ConstantFilterData.cs" />
     <Compile Include="Models\Matches\DefaultIcons.cs" />
@@ -161,6 +163,8 @@
     <Compile Include="Models\Filters\ItemInFilter.cs" />
     <Compile Include="Models\Matches\LeagueSeason.cs" />
     <Compile Include="Models\Matches\LeaguesSeason.cs" />
+    <Compile Include="Models\Matches\MatchesDataFilterContainer.cs" />
+    <Compile Include="Models\Matches\MatchesFilterCohesionData.cs" />
     <Compile Include="Models\Matches\MatchesFiltersValues.cs" />
     <Compile Include="Models\Matches\MatchesModelViewFactory.cs" />
     <Compile Include="Models\Matches\MatchesRawFilterValues.cs" />

--- a/DALK.PL_ANALYZER/DB/FAKE/FakeDB.cs
+++ b/DALK.PL_ANALYZER/DB/FAKE/FakeDB.cs
@@ -40,7 +40,7 @@ namespace DALK.PL_ANALYZER.DB.FAKE
                 (x.Home.GroupSeason.LeagueSeason.Season.Id == parameters.matchSeasonId || parameters.matchSeasonId == null) &&
                 (x.Home.GroupSeason.LeagueSeason.League.Id == parameters.matchLeagueId || parameters.matchLeagueId == null) &&
                 (x.Home.Team.Id == parameters.matchTeamId || parameters.matchTeamId == null) &&
-                //(x.Home.GroupSeason.Id == parameters.matchGroupId || parameters.matchGroupId == null) &&
+                (x.Home.GroupSeason.Id == parameters.matchGroupId || parameters.matchGroupId == null) &&
                 (x.Stage.StageName == parameters.matchStageId || parameters.matchStageId == null)
             ).ToList<Match>();
 
@@ -75,7 +75,7 @@ namespace DALK.PL_ANALYZER.DB.FAKE
         {
             List<TeamSeason> teams = GetListOfTeamSeason().Take(9).ToList<TeamSeason>();
             LeagueFilterData ourLeague = GetPureLeagues().ToList<LeagueFilterData>()[0];
-            SeasonFilterData ourSeason = GetSeasons().GetSeasons().ToList<SeasonFilterData>()[0];
+            SeasonFilterData ourSeason = GetSeasons().GetSeasonFilterData().ToList<SeasonFilterData>()[0];
             GroupFilterData ourGroup = GetGroups().ToList<GroupFilterData>()[0];
             List<Stage> stages = GetStages().ToList<Stage>();
             Player Mrozo = GetPlayers().ToList<Player>()[0];
@@ -159,7 +159,7 @@ namespace DALK.PL_ANALYZER.DB.FAKE
                 MVP = new MVP() { Player = Kurek, PerformanceDesciption = "Double-double (10 punktów (63%), 12 zbiórek)" },
                 Stage = stages[6]
             };
-            
+
             foreach (TeamSeason home in GetListOfTeamSeason())
             {
                 TeamFilterData HomeRandom = home.Team;
@@ -198,7 +198,7 @@ namespace DALK.PL_ANALYZER.DB.FAKE
                         Stage = StageRandom,
                         MVP = PlayerRandom,
                     };
-                } 
+                }
             }
         }
         public IEnumerable<LeagueSeason> GetListOfLeagueSeason()
@@ -207,24 +207,24 @@ namespace DALK.PL_ANALYZER.DB.FAKE
             LeagueFilterData League1 = GetPureLeagues().ToList<LeagueFilterData>()[1];
             LeagueFilterData ExtraLeague = GetPureLeagues().ToList<LeagueFilterData>()[2];
 
-            Season season2019 = GetSeasons().GetSeasons().ToList<Season>()[0];
-            Season season2018_2019 = GetSeasons().GetSeasons().ToList<Season>()[1];
+            Season season2019 = GetSeasons().GetSeasonFilterData().ToList<Season>()[0];
+            Season season2018_2019 = GetSeasons().GetSeasonFilterData().ToList<Season>()[1];
             yield return new LeagueSeason(1)
             {
-                League = League2, 
+                League = League2,
                 Season = season2019
             };
-            yield return new LeagueSeason(1)
+            yield return new LeagueSeason(2)
             {
                 League = League2,
                 Season = season2018_2019
             };
-            yield return new LeagueSeason(1)
+            yield return new LeagueSeason(3)
             {
                 League = League1,
                 Season = season2019
             };
-            yield return new LeagueSeason(1)
+            yield return new LeagueSeason(4)
             {
                 League = ExtraLeague,
                 Season = season2019
@@ -249,12 +249,12 @@ namespace DALK.PL_ANALYZER.DB.FAKE
             yield return new PlayOffStage(5);
             yield return new PlayOffStage(0);
         }
-        public Seasons GetSeasons()
+        public Seasons GetSeasons(int? seasonId = null)
         {
             List<SeasonFilterData> season = new List<SeasonFilterData>();
             season.Add(new SeasonFilterData(1) { FirstYear = 2019, FromDate = new DateTime(2019, 3, 1), ToDate = new DateTime(2019, 6, 30) });
             season.Add(new SeasonFilterData(2) { FirstYear = 2018, SecondYear = 2019, FromDate = new DateTime(2018, 9, 1), ToDate = new DateTime(2019, 1, 31) });
-            return new Seasons(season);
+            return new Seasons(season.Where(x => x.Id == seasonId || seasonId == null));
         }
         public IEnumerable<TeamSeason> GetListOfTeamSeason()
         {
@@ -607,13 +607,23 @@ namespace DALK.PL_ANALYZER.DB.FAKE
             yield return new GroupFilterData(11) { LeagueSeason = ExtraLeagueSeason2019, Name = "A" };
             yield return new GroupFilterData(12) { LeagueSeason = ExtraLeagueSeason2019, Name = "B" };
         }
-        public LeaguesSeason GetLeaguesSeason()
+        public LeaguesSeason GetLeaguesSeason(int? seasonId = null)
         {
-            return new LeaguesSeason(GetListOfLeagueSeason());
+            return new LeaguesSeason(GetListOfLeagueSeason().Where(x => x.Season.Id == seasonId || seasonId == null));
         }
-        public TeamsSeason GetTeamsSeason()
+        public TeamsSeason GetTeamsSeason(int? seasonId = null, int? leagueId = null, int? groupId = null)
         {
-            return new TeamsSeason(GetListOfTeamSeason());
+            return new TeamsSeason(GetListOfTeamSeason().
+                Where(x => (x.GroupSeason.LeagueSeason.League.Id == leagueId || leagueId == null) &&
+                           (x.GroupSeason.LeagueSeason.Season.Id == seasonId || seasonId == null) &&
+                           (x.GroupSeason.Id == groupId || groupId == null)
+            ));
+        }
+        public GroupsSeason GetGroupsSeason(int? seasonId = null, int? leagueId = null)
+        {
+            return new GroupsSeason(
+                GetGroups().Where(x => (x.LeagueSeason.League.Id == leagueId || leagueId == null) &&
+                                       (x.LeagueSeason.Season.Id == seasonId || seasonId == null)));
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Filters/FilterDataCohesion.cs
+++ b/DALK.PL_ANALYZER/Models/Filters/FilterDataCohesion.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DALK.PL_ANALYZER.Models.Filters
+{
+    interface FilterDataCohesion
+    {
+        RawFiltarableValues GetCohesionableData();
+    }
+}

--- a/DALK.PL_ANALYZER/Models/Filters/FilterValue.cs
+++ b/DALK.PL_ANALYZER/Models/Filters/FilterValue.cs
@@ -9,14 +9,17 @@ namespace DALK.PL_ANALYZER.Models.Filters
     {
         public string TypeOfClass { get; set; }   
         public string Value { get; set; }
+        public bool Visible { get; set; }
         public FilterValue(int? value)
         {
             if (value != null)
                 Value = value.ToString();
+            Visible = true;
         }
         public FilterValue(string value)
         {
             Value = value;
+            Visible = true;
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Filters/GridFilters.cs
+++ b/DALK.PL_ANALYZER/Models/Filters/GridFilters.cs
@@ -8,28 +8,32 @@ namespace DALK.PL_ANALYZER.Models.Filters
 {
     public class GridFilters : IFilterableList
     {
-        private readonly List<GridFilter> Fiters;
-
+        private readonly List<GridFilter> Filters;
         public GridFilters() { }
         public GridFilters(List<GridFilter> f)
         {
-            Fiters = new List<GridFilter>(f);
+            Filters = new List<GridFilter>(f);
         }
         private GridFilter GetGridFilter(string typeOfItem)
         {
-            return Fiters
-                .Where(x => x.GetItems().First(y => y.GetItemTypeName() != typeof(EmptyFilterDataItem).ToString()).GetItemTypeName() == typeOfItem)
-                .First();
+            foreach (GridFilter f in Filters)
+            {
+                foreach (IFilterableItem i in f.GetItems().Where(x => x.GetItemTypeName() != typeof(EmptyFilterDataItem).ToString()).Take(1))
+                {
+                    if (i.GetItemTypeName() == typeOfItem)
+                        return f;
+                }
+            }
+            throw new Exception();
         }
         public void SetFilterSelected(FilterValue fV)
         {
             var grid = GetGridFilter(fV.TypeOfClass);
             grid.SetAsSelected(fV.Value);
         }
-
         public IEnumerable<IFilterable> GetFiters()
         {
-            return Fiters;
+            return Filters;
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Filters/RawFiltarableValues.cs
+++ b/DALK.PL_ANALYZER/Models/Filters/RawFiltarableValues.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DALK.PL_ANALYZER.Models.Filters
+{
+    public interface RawFiltarableValues
+    {
+        bool SetDefaultFilters { get; set; }
+    }
+}

--- a/DALK.PL_ANALYZER/Models/Filters/RawFilterValues.cs
+++ b/DALK.PL_ANALYZER/Models/Filters/RawFilterValues.cs
@@ -5,7 +5,7 @@ using System.Web;
 
 namespace DALK.PL_ANALYZER.Models.Filters
 {
-    public class RawFilterValues
+    public class RawFilterValues : RawFiltarableValues
     {
         public bool SetDefaultFilters { get; set; }
     }

--- a/DALK.PL_ANALYZER/Models/Matches/GroupsSeason.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/GroupsSeason.cs
@@ -7,7 +7,7 @@ namespace DALK.PL_ANALYZER.Models.Matches
 {
     public class GroupsSeason
     {
-        private IEnumerable<GroupFilterData> groupSeason;
+        private readonly IEnumerable<GroupFilterData> groupSeason;
         public GroupsSeason(IEnumerable<GroupFilterData> gs = null)
         {
             if (gs == null)
@@ -23,9 +23,13 @@ namespace DALK.PL_ANALYZER.Models.Matches
         {
             groupSeason.ToList<GroupFilterData>().Add(gs);
         }
-        public IEnumerable<GroupFilterData> GetGroupFilterData(LeagueSeason leagueSeason)
+        public IEnumerable<GroupFilterData> Get()
         {
-            return groupSeason.Where(x => x.LeagueSeason == leagueSeason);
+            return groupSeason;
+        }
+        public IEnumerable<GroupFilterData> GetGroupFilterData()
+        {
+            return groupSeason;
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Matches/LeaguesSeason.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/LeaguesSeason.cs
@@ -7,7 +7,7 @@ namespace DALK.PL_ANALYZER.Models.Matches
 {
     public class LeaguesSeason
     {
-        private IEnumerable<LeagueSeason> leagueSeasons;
+        private readonly IEnumerable<LeagueSeason> leagueSeasons;
         public LeaguesSeason()
         {
             leagueSeasons = new List<LeagueSeason>();
@@ -27,11 +27,17 @@ namespace DALK.PL_ANALYZER.Models.Matches
         {
             leagueSeasons.ToList<LeagueSeason>().Add(ls);
         }
-        public IEnumerable<LeagueFilterData> GetLeagueFilterData(Season season = null)
+        public IEnumerable<LeagueSeason> Get()
         {
-            return leagueSeasons
-                .Where(x => x.Season.Equals(season) || season == null)
-                .Select(x => x.League).Distinct().ToList<LeagueFilterData>();
+            return leagueSeasons;
+        }
+        public LeagueSeason GetLeagueSeason(int seasonId, int leagueId)
+        {
+            return leagueSeasons.Where(x => x.League.Id == leagueId && x.Season.Id == seasonId).First();
+        }
+        public IEnumerable<LeagueFilterData> GetLeagueFilterData()
+        {
+            return leagueSeasons.Select(x => x.League).Distinct().ToList<LeagueFilterData>();
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesDataFilterContainer.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesDataFilterContainer.cs
@@ -1,0 +1,72 @@
+﻿using DALK.PL_ANALYZER.DB.FAKE;
+using DALK.PL_ANALYZER.Models.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DALK.PL_ANALYZER.Models.Matches
+{
+    public class MatchesDataFilterContainer
+    {
+        public Seasons Seasons { get; set; }
+        public LeaguesSeason LeaguesSeason { get; set; }
+        public GroupsSeason GroupsSeason { get; set; }
+        public TeamsSeason TeamsSeason { get; set; }
+        public List<IFilterData> Stages { get; set; }
+
+        public MatchesDataFilterContainer(MatchesRawFilterValues rawParameters)
+        {
+            FakeDB db = new FakeDB();
+            Seasons = db.GetSeasons();
+            LeaguesSeason = db.GetLeaguesSeason();
+            if (rawParameters.matchSeasonId != null && rawParameters.matchLeagueId != null)
+            {
+                GroupsSeason = db.GetGroupsSeason(rawParameters.matchSeasonId, rawParameters.matchLeagueId);
+            }            
+            TeamsSeason = db.GetTeamsSeason();
+            Stages = getStageFilters();
+        }
+        public void FilterDataByCohensionable(MatchesRawFilterValues cohensionableParameters)
+        {
+            if (cohensionableParameters.matchSeasonId != null)
+            {
+                LeaguesSeason = new LeaguesSeason(LeaguesSeason.Get().Where(x => x.Season.Id == cohensionableParameters.matchSeasonId));
+            }
+            
+            if (cohensionableParameters.matchSeasonId != null || cohensionableParameters.matchLeagueId != null)
+            {
+                List<TeamSeason> timPrzed = TeamsSeason.Get().ToList<TeamSeason>();
+                List<TeamSeason> tim = TeamsSeason.Get()
+                    .Where(x => (x.GroupSeason.LeagueSeason.League.Id == cohensionableParameters.matchLeagueId || cohensionableParameters.matchLeagueId == null) &&
+                                (x.GroupSeason.LeagueSeason.Season.Id == cohensionableParameters.matchSeasonId || cohensionableParameters.matchSeasonId == null) &&
+                                (x.GroupSeason.Id == cohensionableParameters.matchGroupId || cohensionableParameters.matchGroupId == null)).ToList<TeamSeason>();
+
+                TeamsSeason = new TeamsSeason(TeamsSeason.Get()
+                    .Where(x => (x.GroupSeason.LeagueSeason.League.Id == cohensionableParameters.matchLeagueId || cohensionableParameters.matchLeagueId == null) &&
+                                (x.GroupSeason.LeagueSeason.Season.Id == cohensionableParameters.matchSeasonId || cohensionableParameters.matchSeasonId == null) &&
+                                (x.GroupSeason.Id == cohensionableParameters.matchGroupId || cohensionableParameters.matchGroupId == null)));
+            }           
+        }
+        private List<IFilterData> getStageFilters()
+        {
+            return new List<IFilterData>()
+            {
+                    new ConstantFilterData()
+                    {
+                        Icon = null,
+                        Selected  = false,
+                        Text = "Playoff",
+                        Value = "PlayOff"
+                    },
+                    new ConstantFilterData()
+                    {
+                        Icon = null,
+                        Selected  = false,
+                        Text = "Faza zasadnicza",
+                        Value = "GroupStage"
+                    }
+            };
+        }
+    }
+}

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesFilterCohesionData.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesFilterCohesionData.cs
@@ -1,0 +1,61 @@
+﻿using DALK.PL_ANALYZER.Models.Filters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+
+namespace DALK.PL_ANALYZER.Models.Matches
+{
+    public class MatchesFilterCohesionData : FilterDataCohesion
+    {
+        private MatchesRawFilterValues matchesParameters;
+        private MatchesDataFilterContainer filterData;
+        public MatchesFilterCohesionData(MatchesRawFilterValues matchesParameters, MatchesDataFilterContainer filterData)
+        {
+            this.matchesParameters = (MatchesRawFilterValues)matchesParameters.Clone();
+            this.filterData = filterData;
+        }
+        public RawFiltarableValues GetCohesionableData()
+        {
+            bool IsLeagueCohensionable = IsLeagueIdCohensionable();
+            bool IsTeamCohensionable = IsTeamIdCohensionable();
+            bool IsGroupCohensionable = filterData.GroupsSeason != null ? 
+                    IsGroupIdCohensionable() : false;
+
+            if (!IsLeagueCohensionable)
+            {
+                matchesParameters.matchLeagueId = null;
+            }
+            if (!IsTeamCohensionable)
+            {
+                matchesParameters.matchTeamId = null;
+            }
+            if (!IsGroupCohensionable)
+            {
+                matchesParameters.matchGroupId = null;
+            }
+            return matchesParameters;
+        }
+        private bool IsLeagueIdCohensionable()
+        {
+            return filterData.LeaguesSeason.Get()
+                .Any(x => (x.League.Id == matchesParameters.matchLeagueId) && 
+                          (x.Season.Id == matchesParameters.matchSeasonId || matchesParameters.matchSeasonId == null));
+        }
+        private bool IsTeamIdCohensionable()
+        {
+            return filterData.TeamsSeason.Get()
+                .Any(x => (x.GroupSeason.Id == matchesParameters.matchGroupId || matchesParameters.matchGroupId == null) &&
+                            (x.GroupSeason.LeagueSeason.League.Id == matchesParameters.matchLeagueId || matchesParameters.matchLeagueId == null) &&
+                            (x.GroupSeason.LeagueSeason.Season.Id == matchesParameters.matchSeasonId || matchesParameters.matchSeasonId == null) &&
+                            (x.Team.Id == matchesParameters.matchTeamId));
+        }
+        private bool IsGroupIdCohensionable()
+        {
+            return filterData.GroupsSeason.Get()
+                .Any(x => (x.LeagueSeason.League.Id == matchesParameters.matchLeagueId) &&
+                            (x.LeagueSeason.Season.Id == matchesParameters.matchSeasonId) &&
+                            (x.Id == matchesParameters.matchGroupId));
+        }
+    }
+}

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesFiltersValues.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesFiltersValues.cs
@@ -30,11 +30,12 @@ namespace DALK.PL_ANALYZER.Models.Matches
                     TypeOfClass = typeof(TeamFilterData).ToString()
                 });
 
-            /*filterValues.Add(
+            filterValues.Add(
                 new FilterValue(parameters.matchGroupId)
                 {
-                    TypeOfClass = typeof(GroupFilterData).ToString()
-                });*/
+                    TypeOfClass = typeof(GroupFilterData).ToString(),
+                    Visible = parameters.matchLeagueId != null && parameters.matchSeasonId != null
+                });
     
             filterValues.Add(
                 new FilterValue(parameters.matchStageId)

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesModelView.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesModelView.cs
@@ -25,58 +25,11 @@ namespace DALK.PL_ANALYZER.Models.Matches
         }
         public void SetFilters(MatchesFiltersValues filterValues)
         {
-            foreach (FilterValue fV in filterValues.filterValues)
+            foreach (FilterValue fV in filterValues.filterValues.Where(x => x.Visible))
             {
                 GridFilters.SetFilterSelected(fV);
             }
         }
-        //public IEnumerable<MatchModelView> GetFiltredMatches()
-        //{
-        //    int seasonId = 0;
-        //    int groupId = 0;
-        //    int leagueId = 0;
-        //    int teamId = 0;
-        //    string stage = null;
-            
-        //    foreach (IFilterable f in GridFilters)
-        //    {
-        //        string filterType = f.GetItems().First(x => x.GetItemTypeName() != typeof(EmptyFilterDataItem).ToString()).GetItemTypeName();
-        //        string value = f.GetSelectedItem().GetValue();
-
-        //        if (filterType == typeof(SeasonFilterData).ToString())
-        //        {
-        //            int.TryParse(value, out seasonId);
-        //        }
-        //        else if (filterType == typeof(GroupFilterData).ToString())
-        //        {
-        //            int.TryParse(value, out groupId);
-        //        }
-        //        else if (filterType == typeof(LeagueFilterData).ToString())
-        //        {
-        //            int.TryParse(value, out leagueId);
-        //        }
-        //        else if (filterType == typeof(TeamFilterData).ToString())
-        //        {
-        //            int.TryParse(value, out teamId);
-        //        }
-        //        else if (filterType == typeof(ConstantFilterData).ToString())
-        //        {
-        //            stage = value;
-        //        }
-        //        else
-        //        {
-        //            throw new NotImplementedException();
-        //        } 
-        //    }
-
-        //    return Matches.Where(x =>
-        //     (x.SeasonId == seasonId || seasonId == 0) &&
-        //     (x.GroupId == groupId || groupId == 0) &&
-        //     (x.LeagueId == leagueId || leagueId == 0) &&
-        //     (x.FirstTeamId == teamId || x.SecondTeamId == teamId || teamId == 0) &&
-        //     (x.Stage == stage || stage == null));
-        //}
-
         public GridFilters GridFilters
         {
             get;

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesModelViewFactory.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesModelViewFactory.cs
@@ -16,69 +16,45 @@ namespace DALK.PL_ANALYZER.Models.Matches
         public MatchesModelViewFactory(MatchesRawFilterValues rawParameters)
         {
             db = new FakeDB();
-            MatchesFiltersValues filterValues = new MatchesFiltersValues(rawParameters);                    
-            List<Match> matches = db.GetMatches(rawParameters).ToList<Match>();
+            MatchesDataFilterContainer allDataFilter = new MatchesDataFilterContainer(rawParameters);
+            MatchesFilterCohesionData cohensionData = new MatchesFilterCohesionData(rawParameters, allDataFilter);
+            MatchesRawFilterValues cohensionParameters = (MatchesRawFilterValues)cohensionData.GetCohesionableData();
+            allDataFilter.FilterDataByCohensionable(cohensionParameters);
+            MatchesFiltersValues filterValues = new MatchesFiltersValues(cohensionParameters);                    
+            List<Match> matches = db.GetMatches(cohensionParameters).ToList<Match>();
             matchesMV = new MatchesModelView(matches);
-            matchesMV.GridFilters = getAllFilters(rawParameters);
+            matchesMV.GridFilters = getAllFilters(cohensionParameters, allDataFilter);
             matchesMV.SetFilters(filterValues);
         }
-        private GridFilters getAllFilters(MatchesRawFilterValues rawParameters)
+        private GridFilters getAllFilters(MatchesRawFilterValues cohensionParameters, MatchesDataFilterContainer allDataFilter)
         {            
             List<GridFilter> allFilters = new List<GridFilter>();
             GridFilterFactory gFilterFactory = new GridFilterFactory();
 
-            Seasons seasons = db.GetSeasons();
-            SeasonFilterData defaultSeason = seasons.GetDefaultSeason();
-            GridFilter seasonGridFilter = gFilterFactory.GetGridFilter(seasons.GetSeasons().ToList<IFilterData>(), "Każdy sezon", nameof(rawParameters.matchSeasonId), defaultSeason, rawParameters.SetDefaultFilters);
-            rawParameters.matchSeasonId = seasonGridFilter.SetIdByDefault(rawParameters.matchSeasonId);
+            SeasonFilterData defaultSeason = allDataFilter.Seasons.GetDefaultSeason();
+            GridFilter seasonGridFilter = gFilterFactory.GetGridFilter(allDataFilter.Seasons.GetSeasonFilterData().ToList<IFilterData>(), "Każdy sezon", nameof(cohensionParameters.matchSeasonId), defaultSeason, cohensionParameters.SetDefaultFilters);
+            cohensionParameters.matchSeasonId = seasonGridFilter.SetIdByDefault(cohensionParameters.matchSeasonId);
             allFilters.Add(seasonGridFilter);
 
-            List<ItemInFilter> items = seasonGridFilter.items;
-            List<IFilterableItem> sortedItems = seasonGridFilter.GetItems().ToList<IFilterableItem>();
-
-            LeaguesSeason leaguesSeason = db.GetLeaguesSeason();
-            GridFilter leagueGridFilter = gFilterFactory.GetGridFilter(leaguesSeason.GetLeagueFilterData(defaultSeason).ToList<IFilterData>(), "Każda liga", nameof(rawParameters.matchLeagueId));
-            rawParameters.matchLeagueId = leagueGridFilter.SetIdByDefault(rawParameters.matchLeagueId);
+            GridFilter leagueGridFilter = gFilterFactory.GetGridFilter(allDataFilter.LeaguesSeason.GetLeagueFilterData().ToList<IFilterData>(), "Każda liga", nameof(cohensionParameters.matchLeagueId));
+            cohensionParameters.matchLeagueId = leagueGridFilter.SetIdByDefault(cohensionParameters.matchLeagueId);
             allFilters.Add(leagueGridFilter);
 
-            TeamsSeason teamSeason = db.GetTeamsSeason();
-            GridFilter teamGridFilter = gFilterFactory.GetGridFilter(teamSeason.GetTeamFilterData(defaultSeason).ToList<IFilterData>(), "Każdy zespół", nameof(rawParameters.matchTeamId));
-            rawParameters.matchTeamId = leagueGridFilter.SetIdByDefault(rawParameters.matchTeamId);
+            if (allDataFilter.GroupsSeason != null)
+            {
+                GridFilter groupFilter = gFilterFactory.GetGridFilter(allDataFilter.GroupsSeason.GetGroupFilterData().ToList<IFilterData>(), "Każda grupa", nameof(cohensionParameters.matchGroupId));
+                cohensionParameters.matchGroupId = groupFilter.SetIdByDefault(cohensionParameters.matchGroupId);
+                allFilters.Add(groupFilter);
+            }
+
+            GridFilter teamGridFilter = gFilterFactory.GetGridFilter(allDataFilter.TeamsSeason.GetTeamFilterData().ToList<IFilterData>(), "Każdy zespół", nameof(cohensionParameters.matchTeamId));
+            cohensionParameters.matchTeamId = leagueGridFilter.SetIdByDefault(cohensionParameters.matchTeamId);
             allFilters.Add(teamGridFilter);
 
-            GridFilter stageGridFilter = gFilterFactory.GetGridFilter(getStageFilters(), "Każda faza rozgrywek", nameof(rawParameters.matchStageId));
-            rawParameters.matchStageId = stageGridFilter.SetIdByDefault(rawParameters.matchStageId);
-            allFilters.Add(stageGridFilter);
-
-            /*
-            List<IFilterData> allGroups = db.GetGroups().ToList<IFilterData>();
-            EmptyFilterDataItem groupDefault = new EmptyFilterDataItem("Każda grupa", Configs.DEFAULT_FILTER_ICON);
-            allGroups.Add(groupDefault);
-            GridFilter groupFilter = new GridFilter(allGroups, groupDefault, "matchGroup");          
-            matchGroupId = groupFilter.SetIdByDefault(ref matchGroupId);
-            allFilters.Add(groupFilter)
-            */
+            GridFilter stageGridFilter = gFilterFactory.GetGridFilter(allDataFilter.Stages, "Każda faza rozgrywek", nameof(cohensionParameters.matchStageId));
+            cohensionParameters.matchStageId = stageGridFilter.SetIdByDefault(cohensionParameters.matchStageId);
+            allFilters.Add(stageGridFilter);       
             return new GridFilters(allFilters);
-        }
-        private List<IFilterData> getStageFilters()
-        {
-            return new List<IFilterData>()
-            {
-                    new ConstantFilterData()
-                    {
-                        Icon = null,
-                        Selected  = false,
-                        Text = "Playoff",
-                        Value = "PlayOff"
-                    },
-                    new ConstantFilterData()
-                    {
-                        Icon = null,
-                        Selected  = false,
-                        Text = "Faza zasadnicza",
-                        Value = "GroupStage"
-                    }
-            };
         }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Matches/MatchesRawFilterValues.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/MatchesRawFilterValues.cs
@@ -11,8 +11,11 @@ namespace DALK.PL_ANALYZER.Models.Matches
         public int? matchSeasonId { get; set; }
         public int? matchLeagueId { get; set; }
         public int? matchTeamId { get; set; }
-        //public int? matchGroupId { get; set; }
-        public string matchStageId { get; set; }
-        
+        public int? matchGroupId { get; set; }
+        public string matchStageId { get; set; }      
+        public object Clone()
+        {
+            return this.MemberwiseClone();
+        }
     }
 }

--- a/DALK.PL_ANALYZER/Models/Matches/Seasons.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/Seasons.cs
@@ -20,7 +20,7 @@ namespace DALK.PL_ANALYZER.Models.Matches
         {
             seasons.ToList<Season>().Add(season);
         }
-        public IEnumerable<SeasonFilterData> GetSeasons()
+        public IEnumerable<SeasonFilterData> GetSeasonFilterData()
         {
             return new List<SeasonFilterData>(seasons);
         }

--- a/DALK.PL_ANALYZER/Models/Matches/TeamsSeason.cs
+++ b/DALK.PL_ANALYZER/Models/Matches/TeamsSeason.cs
@@ -7,7 +7,7 @@ namespace DALK.PL_ANALYZER.Models.Matches
 {
     public class TeamsSeason
     {
-        private IEnumerable<TeamSeason> teamSeasons;
+        private readonly IEnumerable<TeamSeason> teamSeasons;
         public TeamsSeason()
         {
             teamSeasons = new List<TeamSeason>();
@@ -27,11 +27,13 @@ namespace DALK.PL_ANALYZER.Models.Matches
         {
             teamSeasons.ToList<TeamSeason>().Add(ts);
         }
-        public IEnumerable<TeamFilterData> GetTeamFilterData(Season season = null, GroupSeason group = null)
+        public IEnumerable<TeamSeason> Get()
         {
-            return teamSeasons
-                 .Where(x => (x.GroupSeason.LeagueSeason.Season.Equals(season) || season == null) && (x.GroupSeason.Equals(group) || group == null))
-                 .Select(x => x.Team).Distinct();
+            return teamSeasons;
+        }
+        public IEnumerable<TeamFilterData> GetTeamFilterData()
+        {
+            return teamSeasons.Select(x => x.Team).Distinct();
         }
     }
 }


### PR DESCRIPTION
…her filter are selected - League and Season.

2. Filter limit not only records of matches, but other filters, for example when season filter is change, results is limit matches to this season and limits teams in filter team.
3. Take care of cohensionable filters, if you select season, then team in this season and change season, which dont consist this team is problem, because this two filters exclude each other, to in that kind of situation we set 'all teams' except keep team which dont consist in season, league etc.